### PR TITLE
Changed color of .syntax--support.syntax--function to aquamarine

### DIFF
--- a/styles/base.less
+++ b/styles/base.less
@@ -165,7 +165,7 @@ atom-text-editor.is-focused .line.cursor-line {
 }
 
 .syntax--support.syntax--function {
-  color: #FFB054;
+  color: #93FFE8;
 }
 
 .syntax--support.syntax--constant {


### PR DESCRIPTION
Changed color of .syntax--support.syntax--function to aquamarine to visualize functions like round, count etc. in SQL. Until now, they had same color as main functions like SELECT etc.